### PR TITLE
link tailscale binary to /usr/local/bin

### DIFF
--- a/src/resource
+++ b/src/resource
@@ -1,5 +1,8 @@
 {
 	"port-config": {
 		"protocol-file": "conf/Tailscale.sc"
+	},
+	"usr-local-linker": {
+		"bin": ["bin/tailscale"]
 	}
 }


### PR DESCRIPTION
Before #61, there was a wrapper script that set the location of the socket.
This is no longer necessary since socket location is now in `tailscale` (https://github.com/tailscale/tailscale/commit/95e296fd964034bc7049979d06fa82df4c39dcb5), but it would be useful to have `tailscale` in the PATH.

This PR adds a synology resource worker config for linking the installed binary to `/usr/local/bin`
