### PR TITLE
build-package.sh: Add 88f6282 (among others)

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -26,7 +26,9 @@ arm64)
   PLATFORMS="armv8"
   ;;
 arm)
-  PLATFORMS="armv7 armada370 armada375 armada38x armadaxp comcerto2k monaco"
+  PLATFORMS_ARM5="armv5 88f6281 88f6282"
+  PLATFORMS_ARM7="armv7 alpine armada370 armada375 armada38x armadaxp comcerto2k monaco hi3535"
+  PLATFORMS="${PLATFORMS_ARM5} ${PLATFORMS_ARM7}"
   ;;
 *)
   # PLATFORMS_PPC="powerpc ppc824x ppc853x ppc854x qoriq"


### PR DESCRIPTION
Add back some architectures not included in:
https://github.com/tailscale/tailscale-synology/commit/2459ade23520fa5ec7ac2a753a23a95adfb07102

Left off ipq806x northstarplus dakota because
https://github.com/SynoCommunity/spksrc/wiki/Architecture-per-Synology-model
says they are no longer receiving updates.

Fixes https://github.com/tailscale/tailscale/issues/2319

Signed-off-by: Denton Gentry <dgentry@tailscale.com>