### PR TITLE
build: build using docker (for use on macosx)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,6 @@ clean:
 
 purge: clean
 	rm -rf spks
+
+build-using-docker:
+	docker run -v `pwd`:/project -w /project buildpack-deps:latest make

--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ make
 ```
 If everything worked you should have a directory called `spks` that contains your SPK files.
 
+### Building on MacOSX
+
+The build scripts currently aren't compatible with MacOSX, as an alternative you can build using [Docker](https://www.docker.com).
+
+```bash
+make build-using-docker
+```
+
 ## Credits and References
 
 - Thanks to [@nirev](https://github.com/nirev) for creating this project and transferring it to Tailscale's GitHub org.


### PR DESCRIPTION
I couldn't get the `make` to run on MacOSX due to compatibles with mktemp and ls tools, as MacOSX is BSD based.

However I was able to build using the `buildpack-dep` docker image.