### PR TITLE
use `/usr/bin/env bash` instead of `bash`

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 
 set -e
 

--- a/src/INFO.sh
+++ b/src/INFO.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 
 VERSION=$1
 ARCH=$2


### PR DESCRIPTION
Otherwise the builds fail in some environments (like `nix-shell`)

Signed-off-by: Maisem Ali <maisem@tailscale.com>