### PR TITLE
build: separate the privileged (package center) builds from sideloaded builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,18 @@ SPK_BUILD = "005"
 
 all: tailscale-amd64 tailscale-386 tailscale-arm64 tailscale-arm
 
+release: tailscale-release-amd64 tailscale-release-386 tailscale-release-arm64 tailscale-release-arm
+
+RELEASE_VERSION_ARG="true"
+SIDELOAD_VERSION_ARG="false"
+
+tailscale-release-%:
+	@./build-package.sh ${TAILSCALE_TRACK} ${TAILSCALE_VERSION} $* ${SPK_BUILD} "6" ${RELEASE_VERSION_ARG}
+	@./build-package.sh ${TAILSCALE_TRACK} ${TAILSCALE_VERSION} $* ${SPK_BUILD} "7" ${RELEASE_VERSION_ARG}
+
 tailscale-%:
-	@./build-package.sh ${TAILSCALE_TRACK} ${TAILSCALE_VERSION} $* ${SPK_BUILD} "6"
-	@./build-package.sh ${TAILSCALE_TRACK} ${TAILSCALE_VERSION} $* ${SPK_BUILD} "7"
+	@./build-package.sh ${TAILSCALE_TRACK} ${TAILSCALE_VERSION} $* ${SPK_BUILD} "6" ${SIDELOAD_VERSION_ARG}
+	@./build-package.sh ${TAILSCALE_TRACK} ${TAILSCALE_VERSION} $* ${SPK_BUILD} "7" ${SIDELOAD_VERSION_ARG}
 
 clean:
 	rm -rf _build _tailscale

--- a/build-package.sh
+++ b/build-package.sh
@@ -7,9 +7,15 @@ TAILSCALE_VERSION=$2
 ARCH=$3
 SPK_BUILD=$4
 DSM_VERSION=$5
+PACKAGE_CENTER_VERSION=$6
+
+PRIVILEGE_FILE="src/privilege-dsm${DSM_VERSION}"
 
 if [[ $DSM_VERSION -eq "7" ]]; then
   SPK_BUILD=$(($SPK_BUILD + 2000))
+  if [[ $PACKAGE_CENTER_VERSION == "true" ]]; then
+    PRIVILEGE_FILE="src/privilege-dsm7.priv"
+  fi
 fi
 
 # architecture taken from:
@@ -26,9 +32,13 @@ arm64)
   PLATFORMS="armv8"
   ;;
 arm)
-  PLATFORMS_ARM5="armv5 88f6281 88f6282"
-  PLATFORMS_ARM7="armv7 alpine armada370 armada375 armada38x armadaxp comcerto2k monaco hi3535"
-  PLATFORMS="${PLATFORMS_ARM5} ${PLATFORMS_ARM7}"
+  if [[ $PACKAGE_CENTER_VERSION == "true" ]]; then
+    PLATFORMS_ARM5="armv5 88f6281 88f6282"
+    PLATFORMS_ARM7="armv7 alpine armada370 armada375 armada38x armadaxp comcerto2k monaco hi3535"
+    PLATFORMS="${PLATFORMS_ARM5} ${PLATFORMS_ARM7}"
+  else
+    PLATFORMS="armv5 armv7"
+  fi
   ;;
 *)
   # PLATFORMS_PPC="powerpc ppc824x ppc853x ppc854x qoriq"
@@ -94,7 +104,7 @@ make_spk() {
   cp -ra src/scripts $spk_tmp_dir
   cp -a src/PACKAGE_ICON*.PNG $spk_tmp_dir
   mkdir ${spk_tmp_dir}/conf
-  cp -a "src/privilege-dsm${DSM_VERSION}" ${spk_tmp_dir}/conf/privilege
+  cp -a ${PRIVILEGE_FILE} ${spk_tmp_dir}/conf/privilege
   cp -a "src/resource" ${spk_tmp_dir}/conf/resource
 
   cp -a src/Tailscale.sc ${spk_tmp_dir}/Tailscale.sc

--- a/src/privilege-dsm7
+++ b/src/privilege-dsm7
@@ -3,11 +3,5 @@
     "run-as": "package"
   },
   "username": "tailscale",
-  "groupname": "tailscale",
-  "tool": [{
-    "relpath": "bin/tailscaled",
-    "user": "package",
-    "group": "package",
-    "capabilities": "cap_net_admin,cap_chown"
-  }]
+  "groupname": "tailscale"
 }

--- a/src/privilege-dsm7.priv
+++ b/src/privilege-dsm7.priv
@@ -1,0 +1,13 @@
+{
+  "defaults":{
+    "run-as": "package"
+  },
+  "username": "tailscale",
+  "groupname": "tailscale",
+  "tool": [{
+    "relpath": "bin/tailscaled",
+    "user": "package",
+    "group": "package",
+    "capabilities": "cap_net_admin,cap_chown"
+  }]
+}


### PR DESCRIPTION
Currently the builds produced can only be installed via the Package Center. This makes it such that we produce different artifacts for the Package Center and for sideloading. Will help facilitate testing of packages.

Signed-off-by: Maisem Ali <maisem@tailscale.com>