### PR TITLE
Drop capabilities field in DSM6. It was incorrect anyways.

### DIFF
--- a/src/privilege-dsm6
+++ b/src/privilege-dsm6
@@ -3,6 +3,5 @@
     "run-as": "root"
   },
   "username": "tailscale",
-  "groupname": "tailscale",
-  "capabilities": "cap_net_admin"
+  "groupname": "tailscale"
 }


### PR DESCRIPTION
Signed-off-by: Maisem Ali <maisem@tailscale.com>