### PR TITLE
Makefile: add support for overriding the TAILSCALE_TRACK and SPK_BUILD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 TAILSCALE_VERSION ?= "1.20.1"
-TAILSCALE_TRACK = "stable"
-# This needs to be monotinically increasing regardless of the TAILSCALE_VERSION
-SPK_BUILD = 17
+TAILSCALE_TRACK ?= "stable"
+# SPK_BUILD is derived from the TAILSCALE_VERSION using the forumla
+#   (major-1)*1e7 + minor*1e4 + patch*1e1 + dsm
+# e.g. for 1.20.1 (dsm7) => 200017
+# Note: The DSM version is appended by the build step.
+SPK_BUILD ?= 20001
 
 .PHONY: tailscale-% clean purge
 

--- a/build-package.sh
+++ b/build-package.sh
@@ -11,14 +11,12 @@ PACKAGE_CENTER_VERSION=$6
 
 PRIVILEGE_FILE="src/privilege-dsm${DSM_VERSION}"
 LOGROTATE_FILE="src/logrotate-dsm${DSM_VERSION}"
+SPK_BUILD="${SPK_BUILD}${DSM_VERSION}"
 
 if [[ $DSM_VERSION -eq "7" ]]; then
-  SPK_BUILD=$(($SPK_BUILD + 2000))
   if [[ $PACKAGE_CENTER_VERSION == "true" ]]; then
     PRIVILEGE_FILE="src/privilege-dsm7.priv"
   fi
-else
-  SPK_BUILD=$(printf "%03d" $SPK_BUILD)
 fi
 
 # architecture taken from:


### PR DESCRIPTION
Also document/use a new format for SPK_BUILD which is derived from the
TAILSCALE_VERSION.