### PR TITLE
build.go: add support to build multiple dsm and arch targets

### DIFF
--- a/src/index.cgi
+++ b/src/index.cgi
@@ -1,0 +1,2 @@
+#! /bin/sh
+exec /var/packages/Tailscale/target/bin/tailscale web -cgi


### PR DESCRIPTION
- fix the todo to only tar/compile the tailscale binary once
- made "speed" the default compression as it's fast and the sizes are
  pretty comparable
- set CGO_ENABLED=0
- use the commit timestamp as the modTime
- set GOARM for arm builds
- add `--for-package-center` flag