### PR TITLE
config: set allUsers=false, only admins can see the app.

### DIFF
--- a/src/config
+++ b/src/config
@@ -3,7 +3,6 @@
 		"SYNO.SDS.Tailscale": {
 			"type": "url",
 			"version": "1.8.3",
-			"allUsers": true,
 			"title": "Tailscale",
 			"icon": "PACKAGE_ICON_256.PNG",
 			"url": "webman/3rdparty/Tailscale/",


### PR DESCRIPTION
Fixes https://github.com/tailscale/tailscale/issues/4759

Signed-off-by: Denton Gentry <dgentry@tailscale.com>