### PR TITLE
start-stop-daemon: truncate log file for stdout.

### DIFF
--- a/src/scripts/start-stop-status
+++ b/src/scripts/start-stop-status
@@ -31,7 +31,7 @@ fi
 start_daemon() {
     local ts=$(date --iso-8601=second)
     echo "${ts} Starting ${SERVICE_NAME} with: ${SERVICE_COMMAND}" >${LOG_FILE}
-    STATE_DIRECTORY=${PKGVAR} ${SERVICE_COMMAND} >>${LOG_FILE} 2>&1 &
+    STATE_DIRECTORY=${PKGVAR} ${SERVICE_COMMAND} 2>&1 | sed -u '1,200p;201s,.*,[further tailscaled logs suppressed],p;d' >>${LOG_FILE} &
     echo "$!" >"${PID_FILE}"
 }
 


### PR DESCRIPTION
The initial part of that file can be useful if tailscaled is crashing or has other failures during startup. We don't want to keep the disk from hibernating by writing to it after startup.

Fixes https://github.com/tailscale/tailscale/issues/7007

Signed-off-by: Denton Gentry <dgentry@tailscale.com>