### PR TITLE
build: add DSM version as the leading digits.

### DIFF
--- a/build.go
+++ b/build.go
@@ -157,7 +157,7 @@ func readCommitTime(dir string) (time.Time, error) {
 }
 
 func (p spkParams) spkBuild(dsm int) int {
-	return 10*p.spkBuildBase + dsm
+	return dsm*1e8 + p.spkBuildBase
 }
 
 func (p spkParams) versionDashBuild(dsm int) string {

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/tailscale/tailscale-synology
 
-go 1.17
+go 1.20
 
 require github.com/ulikunitz/xz v0.5.10
+
+require tailscale.com v1.40.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+tailscale.com v1.40.0 h1:3guThaC1cCSHQ2nAk0ChQ8D5CCQmfwcQFTUcfpBrKPE=
+tailscale.com v1.40.0/go.mod h1:j5vekUD4eLhLpHl/tNBps25strCOBXyiKUsdR1HhMq8=


### PR DESCRIPTION
As of May 2023, Synology requires that the DSM version be the first two digits of the build number.
This is required to be "60" for DSM6 and "70" for DSM7.

We now  generate package names of the form:
- tailscale-x86_64-1.41.17-600041017-dsm6.spk
- tailscale-x86_64-1.41.17-700041017-dsm7.spk

where:
- "60" or "70" are the DSM version.
- "0" is the major release - 1. Our major release is currently 1.
- "041" is the minor release number, Tailscale 1.41 in this example.
- "017" is the patch number, 17 commits past 1.41.0.

We're keeping the -dsm# at the end of the filename, because the leading "60" or "70" is subtle and not clear to people who only occasionally interact with Synology software package formats.

Fixes https://github.com/tailscale/corp/issues/10405