### PR TITLE
start-stop-status: find the correct PID for tailscaled.

### DIFF
--- a/src/scripts/start-stop-status
+++ b/src/scripts/start-stop-status
@@ -32,7 +32,9 @@ start_daemon() {
     local ts=$(date --iso-8601=second)
     echo "${ts} Starting ${SERVICE_NAME} with: ${SERVICE_COMMAND}" >${LOG_FILE}
     STATE_DIRECTORY=${PKGVAR} ${SERVICE_COMMAND} 2>&1 | sed -u '1,200p;201s,.*,[further tailscaled logs suppressed],p;d' >>${LOG_FILE} &
-    echo "$!" >"${PID_FILE}"
+    # We pipe tailscaled's output to sed, so "$!" retrieves the PID of sed not tailscaled.
+    # Use jobs -p to retrieve the PID of the most recent process group leader.
+    jobs -p >"${PID_FILE}"
 }
 
 stop_daemon() {


### PR DESCRIPTION
Because we pipe tailscaled's output to sed:
`tailscaled | sed -e "..." >> logfile`
Using "$!" retrieves the PID of sed, not the PID of tailscaled. This breaks the stop action of start-stop-status, it kills the wrong process.

Use `jobs -p` instead to retrieve the PID of the most recent process group leader.

Fixes https://github.com/tailscale/corp/issues/10404